### PR TITLE
Fix for react-native 0.56

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ let _applyed = false
 export default class GlobalFont {
     static applyGlobal(fontFamily) {
         if (_applyed) { return }
-        Text.prototype.render = wrap(Text.prototype.render, function (func, ...args) {
+        Text.render = wrap(Text.render, function (func, ...args) {
             let originText = func.apply(this, args)
             return React.cloneElement(originText, {
                 style: [


### PR DESCRIPTION
Updated Text.prototype.render to Text.render.
Text in react-native 0.56 does not have prototype property